### PR TITLE
Fix README wording for Cloud Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ gcloud run deploy trophybot \
   --port 8080
 ```
 
-This deploys `main.py` as an HTTP endpoint on Cloud Run, verifying request signatures and handling `/roll_d6` commands.
+This deploys `main.py` as an HTTP endpoint on Cloud Run, verifying request signatures and handling `/roll` commands.


### PR DESCRIPTION
## Summary
- adjust Cloud Run deployment section wording to indicate `/roll` commands are handled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_6848e8a808688321bc265ebe196a634a