### PR TITLE
Remove CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,3 @@ extend-ignore = ["D100", "D205"]         # e.g. skip missing docstring for modul
 exclude = ["build/", "docs/"]    
 per-file-ignores = { "tests/*" = ["D", "S101"] }      # relax docstring & security in tests
 
-[tool.poetry.scripts]
-trophybot = "trophybot.bot:main"

--- a/src/trophybot/__main__.py
+++ b/src/trophybot/__main__.py
@@ -1,6 +1,0 @@
-"""Entry point for the trophybot Discord bot."""
-
-from trophybot.bot import main
-
-if __name__ == "__main__":
-    main()

--- a/src/trophybot/bot.py
+++ b/src/trophybot/bot.py
@@ -122,3 +122,4 @@ async def _roll_command(interaction):
 
 
 roll_command = _Command(_roll_command)
+

--- a/src/trophybot/dice.py
+++ b/src/trophybot/dice.py
@@ -18,5 +18,11 @@ roll = roll_d6
 
 
 def roll_pool(n: int) -> List[int]:
-    """Roll a pool of six-sided dice."""
+    """
+    Roll a pool of ``n`` six-sided dice.
+
+    Raises ``ValueError`` if ``n`` is negative.
+    """
+    if n < 0:
+        raise ValueError("n must be non-negative")
     return [roll_d6() for _ in range(n)]

--- a/tests/test_dice_engine.py
+++ b/tests/test_dice_engine.py
@@ -1,3 +1,5 @@
+import pytest
+
 from trophybot.dice import roll_d6, roll_pool
 
 
@@ -15,3 +17,8 @@ def test_roll_pool_range():
     pool = roll_pool(2)
     assert 1 <= pool[0] <= 6
     assert 1 <= pool[1] <= 6
+
+
+def test_roll_pool_negative():
+    with pytest.raises(ValueError):
+        roll_pool(-1)


### PR DESCRIPTION
## Summary
- remove the now-unused `__main__` module
- remove the CLI definition from pyproject
- validate that negative pool sizes error

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e663fda883219efc4ee04f025766