### PR TITLE
Add plain text /roll parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Use the following slash commands in Discord:
   - if issued as `/roll [light]` (e.g. `/roll 2`), it rolls that many light-type d6s and reports all dice rolls, then indicates the highest
   - if issued as `/roll [dark]` (e.g. `/roll 3`), it rolls that many dark-type d6s and reports all dice rolls, then indicates the highest
   - if issued as `/roll [light] [dark]` (e.g. `/roll light=2 dark=3`), it rolls that many light-type and dark-type d6s, shows all results grouped by color, and indicates the highest die and its color (e.g., "Light 1 5 Dark 3 4 6 => Dark 6 is highest"). Per the rules, if there is a tie between the highest light and dark dice, the dark die wins
+  - you can also simply type `/roll 2 3` as plain text; it will be treated the same as `/roll light:2 dark:3`
 
 ## Cloud Run Deployment
 

--- a/deploy.py
+++ b/deploy.py
@@ -46,6 +46,12 @@ COMMANDS = [
                 "type": 4,  # INTEGER
                 "required": False,
             },
+            {
+                "name": "text",
+                "description": "Plain text input like '2 3'",
+                "type": 3,  # STRING
+                "required": False,
+            },
         ],
     },
     {

--- a/src/trophybot/bot.py
+++ b/src/trophybot/bot.py
@@ -72,18 +72,33 @@ async def _handle_combined_dice_roll(
     )
 
 
+def _parse_roll_options(options_list):
+    """Return a dict with light/dark counts parsed from options."""
+    parsed: dict[str, int] = {}
+    for opt in options_list or []:
+        name = opt["name"]
+        value = opt["value"]
+        if name in {"light", "dark"}:
+            parsed[name] = value
+            continue
+        if isinstance(value, str):
+            nums = [int(t) for t in value.split() if t.isdigit()]
+            if nums:
+                parsed.setdefault("light", nums[0])
+            if len(nums) >= 2:
+                parsed.setdefault("dark", nums[1])
+    return parsed
+
+
 async def _roll_command(interaction):
     """Roll a d6 or pool as the generic /roll command."""
-    options_list = (
+    options = (
         interaction.data.options
         if hasattr(interaction.data, "options") and interaction.data.options is not None
         else []
     )
 
-    parsed_options = {}
-    if options_list:
-        for opt in options_list:
-            parsed_options[opt["name"]] = opt["value"]
+    parsed_options = _parse_roll_options(options)
 
     light_dice_count = parsed_options.get("light")
     dark_dice_count = parsed_options.get("dark")

--- a/src/trophybot/bot.py
+++ b/src/trophybot/bot.py
@@ -75,18 +75,29 @@ async def _handle_combined_dice_roll(
 def _parse_roll_options(options_list):
     """Return a dict with light/dark counts parsed from options."""
     parsed: dict[str, int] = {}
+    extra_numbers: list[int] = []
+
     for opt in options_list or []:
-        name = opt["name"]
-        value = opt["value"]
+        name = opt.get("name")
+        value = opt.get("value")
+
         if name in {"light", "dark"}:
             parsed[name] = value
             continue
+
+        text_parts: list[str] = []
         if isinstance(value, str):
-            nums = [int(t) for t in value.split() if t.isdigit()]
-            if nums:
-                parsed.setdefault("light", nums[0])
-            if len(nums) >= 2:
-                parsed.setdefault("dark", nums[1])
+            text_parts.extend(value.split())
+        if isinstance(name, str):
+            text_parts.extend(name.split())
+
+        extra_numbers.extend(int(t) for t in text_parts if t.isdigit())
+
+    if "light" not in parsed and extra_numbers:
+        parsed["light"] = extra_numbers.pop(0)
+    if "dark" not in parsed and extra_numbers:
+        parsed["dark"] = extra_numbers.pop(0)
+
     return parsed
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -177,6 +177,25 @@ from trophybot.bot import roll_command
             },
             "Light 2 5 1 => Light 5 is highest",
         ),
+        (
+            "numbers_in_name",
+            [
+                {"name": "2", "value": ""},
+                {"name": "3", "value": ""},
+            ],
+            {
+                "roll_pool": lambda count: (
+                    [1, 6]
+                    if count == 2
+                    else (
+                        [2, 4, 5]
+                        if count == 3
+                        else pytest.fail(f"Unexpected roll_pool count: {count}")
+                    )
+                )
+            },
+            "Light 1 6 Dark 2 4 5 => Light 6 is highest",
+        ),
     ],
     ids=[
         "no_options_single_d6",
@@ -191,6 +210,7 @@ from trophybot.bot import roll_command
         "light_and_dark_tie_dark_wins",
         "plain_text_two_numbers",
         "plain_text_one_number",
+        "numbers_in_name",
     ],
 )
 async def test_roll_command_scenarios(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -149,6 +149,34 @@ from trophybot.bot import roll_command
             # Expected: Dark 5 wins due to tie-breaking rule
             "Light 5 1 Dark 2 5 => Dark 5 is highest",
         ),
+        (
+            "plain_text_two_numbers",  # user typed "/roll 2 3" as plain text
+            [{"name": "text", "value": "2 3"}],
+            {
+                "roll_pool": lambda count: (
+                    [1, 6]
+                    if count == 2
+                    else (
+                        [2, 5, 3]
+                        if count == 3
+                        else pytest.fail(f"Unexpected roll_pool count: {count}")
+                    )
+                )
+            },
+            "Light 1 6 Dark 2 5 3 => Light 6 is highest",
+        ),
+        (
+            "plain_text_one_number",  # user typed "/roll 2" as plain text
+            [{"name": "text", "value": "2"}],
+            {
+                "roll_pool": lambda count: (
+                    [2, 5, 1]
+                    if count == 2
+                    else pytest.fail(f"Unexpected roll_pool count: {count}")
+                )
+            },
+            "Light 2 5 1 => Light 5 is highest",
+        ),
     ],
     ids=[
         "no_options_single_d6",
@@ -161,6 +189,8 @@ from trophybot.bot import roll_command
         "light_zero_dark_zero_via_light_option",
         "light_zero_dark_zero_explicit",
         "light_and_dark_tie_dark_wins",
+        "plain_text_two_numbers",
+        "plain_text_one_number",
     ],
 )
 async def test_roll_command_scenarios(


### PR DESCRIPTION
## Summary
- interpret unrecognized options as plain text numbers for `/roll`
- note plain text syntax in README
- test plain text input
- refactor roll command option parsing

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e86af6588321bbb94c9ebf84284a