### PR TITLE
Add /combat command

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ app = Flask(__name__)
 # Allow importing trophybot package from src directory.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
-from trophybot.bot import roll_command  # noqa: E402
+from trophybot.bot import combat_command, roll_command  # noqa: E402
 
 
 def _verify_discord_request(current_request):
@@ -95,6 +95,9 @@ async def _handle_application_command(payload):
     if name == "roll":
         print("DEBUG: Routing to roll_command.callback")
         return await roll_command.callback(fake_interaction_obj)
+    if name == "combat":
+        print("DEBUG: Routing to combat_command.callback")
+        return await combat_command.callback(fake_interaction_obj)
 
     print(f"DEBUG: Unknown command: {name}")
     return {"type": 4, "data": {"content": f"Unknown command: {name}"}}

--- a/tests/test_combat_command.py
+++ b/tests/test_combat_command.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from trophybot.bot import combat_command
+
+
+@pytest.mark.asyncio
+async def test_combat_command_failure(monkeypatch):
+    monkeypatch.setattr("trophybot.dice.roll_pool", lambda count: [2, 3, 5])
+
+    responses = []
+
+    async def fake_send(message):
+        responses.append(message)
+
+    fake_interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=fake_send),
+        data=SimpleNamespace(
+            options=[
+                {"name": "dark", "value": 3},
+                {"name": "endurance", "value": 9},
+            ]
+        ),
+    )
+
+    await combat_command.callback(fake_interaction)
+
+    expected = (
+        "Dice: 2 3 5\n"
+        "Top 2: 3+5 = 8\n"
+        "Outcome: Failure (< 9)\n"
+        "If any die matches your weak point, mark Ruin"
+    )
+    assert responses == [expected]
+
+
+@pytest.mark.asyncio
+async def test_combat_command_success(monkeypatch):
+    monkeypatch.setattr("trophybot.dice.roll_pool", lambda count: [4, 6])
+
+    responses = []
+
+    async def fake_send(message):
+        responses.append(message)
+
+    fake_interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=fake_send),
+        data=SimpleNamespace(
+            options=[
+                {"name": "dark", "value": 2},
+                {"name": "endurance", "value": 9},
+            ]
+        ),
+    )
+
+    await combat_command.callback(fake_interaction)
+
+    expected = (
+        "Dice: 4 6\n"
+        "Top 2: 4+6 = 10\n"
+        "Outcome: Success (>= 9)\n"
+        "If any die matches your weak point, mark Ruin"
+    )
+    assert responses == [expected]

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -98,3 +98,31 @@ def test_roll_endpoint_with_light_and_dark_options(client, monkeypatch):
     assert data["type"] == 4
     expected_content = "Light 1 6 Dark 2 5 3 => Light 6 is highest"
     assert data["data"]["content"] == expected_content
+
+
+def test_combat_endpoint(client, monkeypatch):
+    monkeypatch.setattr("trophybot.dice.roll_pool", lambda count: [2, 3, 5])
+
+    payload_data = {
+        "type": 2,
+        "data": {
+            "name": "combat",
+            "options": [
+                {"name": "dark", "value": 3},
+                {"name": "endurance", "value": 9},
+            ],
+        },
+    }
+    body = json.dumps(payload_data).encode()
+    resp = client.post("/", data=body, headers=make_headers(body))
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["type"] == 4
+    expected_content = (
+        "Dice: 2 3 5\n"
+        "Top 2: 3+5 = 8\n"
+        "Outcome: Failure (< 9)\n"
+        "If any die matches your weak point, mark Ruin"
+    )
+    assert data["data"]["content"] == expected_content


### PR DESCRIPTION
## Summary
- implement Trophy Gold endurance test handler
- expose new `combat_command` in bot
- register `/combat` in command router
- test combat command behavior and integration

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f417c290832187df99e429c51389