### PR TITLE
Update roll command parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ trophybot is a Discord dice roller for the Trophy RPG.
 
 Use the following slash commands in Discord:
 
-- `/roll [light] [dark]`
-  - if issued just as `/roll`, it rolls one d6 and reports the result
-  - if issued as `/roll [light]` (e.g. `/roll 2`), it rolls that many light-type d6s and reports all dice rolls, then indicates the highest
-  - if issued as `/roll [dark]` (e.g. `/roll 3`), it rolls that many dark-type d6s and reports all dice rolls, then indicates the highest
-  - if issued as `/roll [light] [dark]` (e.g. `/roll light=2 dark=3`), it rolls that many light-type and dark-type d6s, shows all results grouped by color, and indicates the highest die and its color (e.g., "Light 1 5 Dark 3 4 6 => Dark 6 is highest"). Per the rules, if there is a tie between the highest light and dark dice, the dark die wins
-  - you can also simply type `/roll 2 3` as plain text; it will be treated the same as `/roll light:2 dark:3`
+- `/roll [input]`
+  - `input` is optional text that may contain zero, one, or two digits
+  - with no digits (plain `/roll`), a single die is rolled and the result reported
+  - with one digit (e.g. `/roll 3`), that many dice are rolled, all results are listed, and the highest die is noted
+  - with two digits (e.g. `/roll 2 3`), two pools are rolled – the first is "light" and the second "dark" – and the highest die and its colour are reported (dark wins any ties)
 
 ## Cloud Run Deployment
 

--- a/deploy.py
+++ b/deploy.py
@@ -35,23 +35,11 @@ COMMANDS = [
         "description": "Roll a six-sided die or pool",
         "options": [
             {
-                "name": "light",
-                "description": "Number of light dice",
-                "type": 4,  # INTEGER
-                "required": False,
-            },
-            {
-                "name": "dark",
-                "description": "Number of dark dice (default 0)",
-                "type": 4,  # INTEGER
-                "required": False,
-            },
-            {
-                "name": "text",
-                "description": "Plain text input like '2 3'",
+                "name": "input",
+                "description": "Text containing zero, one or two digits",
                 "type": 3,  # STRING
                 "required": False,
-            },
+            }
         ],
     },
     {

--- a/src/trophybot/bot.py
+++ b/src/trophybot/bot.py
@@ -1,3 +1,4 @@
+import re
 import trophybot.dice
 
 
@@ -7,144 +8,81 @@ class _Command:
 
 
 async def _handle_single_d6_roll(interaction):
-    """Handle rolling a single d6 when no options are provided."""
+    """Roll a single d6."""
     result = trophybot.dice.roll_d6()
-    return await interaction.response.send_message(f"🎲 You rolled: {result}")
+    return await interaction.response.send_message(f"Die roll: {result}")
 
 
-async def _handle_light_dice_roll(interaction, light_dice_count: int):
-    """Handle rolling light dice when dark dice are not involved or are zero."""
-    # Precondition: light_dice_count > 0
-    rolls = trophybot.dice.roll_pool(light_dice_count)
+async def _handle_pool_roll(interaction, count: int):
+    """Roll ``count`` six-sided dice and report the highest."""
+    if count <= 0:
+        return await interaction.response.send_message("No dice rolled.")
+    rolls = trophybot.dice.roll_pool(count)
     highest = max(rolls)
     return await interaction.response.send_message(
-        f"Light {' '.join(map(str, rolls))} => Light {highest} is highest"
+        f"Dice rolls: {' '.join(map(str, rolls))} => Highest {highest}"
     )
 
 
-async def _handle_dark_dice_roll(interaction, dark_dice_count: int):
-    """Handle rolling dark dice when light dice are not specified or are zero."""
-    # Precondition: dark_dice_count > 0
-    dark_rolls = trophybot.dice.roll_pool(dark_dice_count)
-    highest_dark = max(dark_rolls)
-    return await interaction.response.send_message(
-        f"Dark {' '.join(map(str, dark_rolls))} => Dark {highest_dark} is highest"
-    )
-
-
-async def _handle_combined_dice_roll(
-    interaction, light_dice_count: int, dark_dice_count: int
+async def _handle_light_dark_roll(
+    interaction, light_count: int, dark_count: int
 ):
-    """Handle rolling both light and dark dice."""
-    # Preconditions: dark_dice_count > 0. light_dice_count >= 0.
-    light_rolls = []
-    if light_dice_count > 0:
-        light_rolls = trophybot.dice.roll_pool(light_dice_count)
+    """Roll light and dark dice pools and report the highest with tie-breaking."""
+    if light_count <= 0 and dark_count <= 0:
+        return await interaction.response.send_message("No dice rolled.")
 
-    # dark_dice_count is > 0
-    assert isinstance(dark_dice_count, int) and dark_dice_count > 0, (
-        "Logical error: dark_dice_count should be a positive integer here."
-    )
-    dark_rolls = trophybot.dice.roll_pool(dark_dice_count)
+    light_rolls = trophybot.dice.roll_pool(light_count) if light_count > 0 else []
+    dark_rolls = trophybot.dice.roll_pool(dark_count) if dark_count > 0 else []
 
-    all_rolls_tagged = []
-    # We only add light rolls to all_rolls_tagged if light_dice_count > 0
-    all_rolls_tagged.extend([(roll, "Light") for roll in light_rolls])
-    all_rolls_tagged.extend([(roll, "Dark") for roll in dark_rolls])
+    tagged = [(r, "Light") for r in light_rolls] + [
+        (r, "Dark") for r in dark_rolls
+    ]
 
-    # Since dark_rolls is non-empty, all_rolls_tagged will be non-empty.
-    # To handle ties where dark dice win, we use a tuple as the key for max().
-    # The 1st element is the roll value, the 2nd is a preference score (Dark > Light)
-    highest_roll_val, highest_roll_type = max(
-        all_rolls_tagged, key=lambda x: (x[0], 1 if x[1] == "Dark" else 0)
+    highest_val, highest_type = max(
+        tagged, key=lambda x: (x[0], 1 if x[1] == "Dark" else 0)
     )
 
-    message_parts = []
-    if light_rolls:  # True if light_dice_count > 0
-        message_parts.append(f"Light {' '.join(map(str, light_rolls))}")
-    message_parts.append(
-        f"Dark {' '.join(map(str, dark_rolls))}"
-    )  # dark_rolls is never empty here
+    parts = []
+    if light_rolls:
+        parts.append(f"Light rolls: {' '.join(map(str, light_rolls))}")
+    if dark_rolls:
+        parts.append(f"Dark rolls: {' '.join(map(str, dark_rolls))}")
 
-    roll_summary_str = " ".join(message_parts)
-    return await interaction.response.send_message(
-        f"{roll_summary_str} => {highest_roll_type} {highest_roll_val} is highest"
-    )
+    message = " ".join(parts) + f" => Highest {highest_type} {highest_val}"
+    return await interaction.response.send_message(message)
 
 
-def _parse_roll_options(options_list):
-    """Return a dict with light/dark counts parsed from options."""
-    parsed: dict[str, int] = {}
-    extra_numbers: list[int] = []
-
+def _extract_digits(options_list):
+    """Return a list of digits found in the 'input' option string."""
+    input_text = ""
     for opt in options_list or []:
-        name = opt.get("name")
-        value = opt.get("value")
-
-        if name in {"light", "dark"}:
-            parsed[name] = value
-            continue
-
-        text_parts: list[str] = []
-        if isinstance(value, str):
-            text_parts.extend(value.split())
-        if isinstance(name, str):
-            text_parts.extend(name.split())
-
-        extra_numbers.extend(int(t) for t in text_parts if t.isdigit())
-
-    if "light" not in parsed and extra_numbers:
-        parsed["light"] = extra_numbers.pop(0)
-    if "dark" not in parsed and extra_numbers:
-        parsed["dark"] = extra_numbers.pop(0)
-
-    return parsed
+        if opt.get("name") == "input":
+            value = opt.get("value")
+            if isinstance(value, str):
+                input_text = value
+            else:
+                input_text = str(value)
+            break
+    return [int(d) for d in re.findall(r"\d", input_text)]
 
 
 async def _roll_command(interaction):
-    """Roll a d6 or pool as the generic /roll command."""
+    """Generic /roll command using a single text input option."""
     options = (
         interaction.data.options
         if hasattr(interaction.data, "options") and interaction.data.options is not None
         else []
     )
 
-    parsed_options = _parse_roll_options(options)
+    digits = _extract_digits(options)
 
-    light_dice_count = parsed_options.get("light")
-    dark_dice_count = parsed_options.get("dark")
-
-    # Case 1: No options provided (plain /roll)
-    if light_dice_count is None and dark_dice_count is None:
+    if len(digits) == 0:
         return await _handle_single_d6_roll(interaction)
-    # Case 2: Light dice specified, dark dice are zero or not specified
-    elif light_dice_count is not None and (
-        dark_dice_count is None or dark_dice_count == 0
-    ):
-        if light_dice_count == 0:
-            return await interaction.response.send_message("🎲 No dice rolled.")
-        else:  # light_dice_count > 0
-            return await _handle_light_dice_roll(interaction, light_dice_count)
-    # Case 3: Dark dice specified, light dice are not specified
-    # (dark_dice_count must be non-None here due to previous conditions)
-    elif light_dice_count is None:
-        # dark_dice_count is guaranteed to be non-None here, otherwise Case 1 applies.
-        if dark_dice_count == 0:
-            return await interaction.response.send_message("🎲 No dice rolled.")
-        else:  # dark_dice_count > 0
-            return await _handle_dark_dice_roll(interaction, dark_dice_count)  # type: ignore
-    # Case 4: Both light and dark dice are specified, and dark_dice_count > 0
-    # (light_dice_count can be >= 0 here)
-    else:
-        # This implies:
-        # - light_dice_count is not None (it's an int, could be 0)
-        # - dark_dice_count is not None and dark_dice_count > 0
-        #   (if dark_dice_count was 0, it would have been caught by Case 2)
-        return await _handle_combined_dice_roll(
-            interaction,
-            light_dice_count,
-            dark_dice_count,  # type: ignore
-        )
+    if len(digits) == 1:
+        return await _handle_pool_roll(interaction, digits[0])
+
+    # Two or more digits - only first two matter
+    return await _handle_light_dark_roll(interaction, digits[0], digits[1])
 
 
 roll_command = _Command(_roll_command)

--- a/src/trophybot/bot.py
+++ b/src/trophybot/bot.py
@@ -1,4 +1,5 @@
 import re
+
 import trophybot.dice
 
 
@@ -24,9 +25,7 @@ async def _handle_pool_roll(interaction, count: int):
     )
 
 
-async def _handle_light_dark_roll(
-    interaction, light_count: int, dark_count: int
-):
+async def _handle_light_dark_roll(interaction, light_count: int, dark_count: int):
     """Roll light and dark dice pools and report the highest with tie-breaking."""
     if light_count <= 0 and dark_count <= 0:
         return await interaction.response.send_message("No dice rolled.")
@@ -34,9 +33,7 @@ async def _handle_light_dark_roll(
     light_rolls = trophybot.dice.roll_pool(light_count) if light_count > 0 else []
     dark_rolls = trophybot.dice.roll_pool(dark_count) if dark_count > 0 else []
 
-    tagged = [(r, "Light") for r in light_rolls] + [
-        (r, "Dark") for r in dark_rolls
-    ]
+    tagged = [(r, "Light") for r in light_rolls] + [(r, "Dark") for r in dark_rolls]
 
     highest_val, highest_type = max(
         tagged, key=lambda x: (x[0], 1 if x[1] == "Dark" else 0)
@@ -67,7 +64,7 @@ def _extract_digits(options_list):
 
 
 async def _roll_command(interaction):
-    """Generic /roll command using a single text input option."""
+    """Handle the generic /roll command using a single text input option."""
     options = (
         interaction.data.options
         if hasattr(interaction.data, "options") and interaction.data.options is not None

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-# tests/test_commands.py
 from types import SimpleNamespace
 
 import pytest
@@ -8,218 +7,26 @@ from trophybot.bot import roll_command
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "test_id, options_data, dice_mocks, expected_message",
+    "options_data, dice_mocks, expected",
     [
+        ([], {"roll_d6": lambda: 4}, "Die roll: 4"),
         (
-            "no_options_single_d6",
-            [],
-            {"roll_d6": lambda: 4},
-            "🎲 You rolled: 4",
+            [{"name": "input", "value": "3"}],
+            {"roll_pool": lambda count: [3, 5, 2] if count == 3 else pytest.fail(f"Unexpected {count}")},
+            "Dice rolls: 3 5 2 => Highest 5",
         ),
         (
-            "only_light_gt_1",
-            [{"name": "light", "value": 3}],
+            [{"name": "input", "value": "2 3"}],
             {
-                "roll_pool": lambda count: (
-                    [2, 5, 1]
-                    if count == 3
-                    else pytest.fail(f"Unexpected roll_pool count: {count}")
-                )
-            },
-            "Light 2 5 1 => Light 5 is highest",
-        ),
-        (
-            "only_dark_specified",  # User issues /roll dark=D, means 0 light dice.
-            [{"name": "dark", "value": 2}],
-            {
-                "roll_pool": lambda count: (
-                    [4, 1]
-                    if count == 2  # Only dark dice pool should be rolled
-                    else pytest.fail(f"Unexpected roll_pool count: {count}")
-                )
-            },
-            "Dark 4 1 => Dark 4 is highest",
-        ),
-        (
-            "light_and_dark_light_highest",  # light=2, dark=3
-            [
-                {"name": "light", "value": 2},
-                {"name": "dark", "value": 3},
-            ],
-            {
-                "roll_pool": lambda count: (
-                    [1, 6]
-                    if count == 2
-                    else (
-                        [2, 5, 3]
-                        if count == 3
-                        else pytest.fail(f"Unexpected roll_pool count: {count}")
-                    )
-                ),
-            },
-            "Light 1 6 Dark 2 5 3 => Light 6 is highest",
-        ),
-        (
-            "light_and_dark_dark_highest",  # light=1, dark=2
-            [
-                {"name": "light", "value": 1},
-                {"name": "dark", "value": 2},
-            ],
-            {
-                "roll_pool": lambda count: (
-                    [3]
-                    if count == 1
-                    else (
-                        [4, 1]
-                        if count == 2
-                        else pytest.fail(f"Unexpected roll_pool count: {count}")
-                    )
-                ),
-            },
-            "Light 3 Dark 4 1 => Dark 4 is highest",
-        ),
-        (
-            "light_zero_dark_gt_zero",  # light=0, dark=2
-            [
-                {"name": "light", "value": 0},
-                {"name": "dark", "value": 2},
-            ],
-            {
-                "roll_pool": lambda count: (
-                    [4, 1]
-                    if count == 2
-                    else pytest.fail(f"Unexpected roll_pool count: {count}")
-                )
-            },
-            # If light dice are 0, they are not mentioned in the roll list
-            "Dark 4 1 => Dark 4 is highest",
-        ),
-        (
-            "light_gt_zero_dark_zero",  # light=2, dark=0 (explicitly)
-            [
-                {"name": "light", "value": 2},
-                {"name": "dark", "value": 0},
-            ],
-            {
-                "roll_pool": lambda count: (
-                    [2, 5, 1]
-                    if count == 2
-                    else pytest.fail(f"Unexpected roll_pool count: {count}")
-                )
-            },
-            # If dark dice are 0, they are not mentioned
-            "Light 2 5 1 => Light 5 is highest",
-        ),
-        (
-            "light_zero_dark_zero_via_light_option",  # light=0 (dark defaults to 0)
-            [{"name": "light", "value": 0}],
-            {},  # No dice functions should be called
-            "🎲 No dice rolled.",
-        ),
-        (
-            "light_zero_dark_zero_explicit",  # light=0, dark=0
-            [
-                {"name": "light", "value": 0},
-                {"name": "dark", "value": 0},
-            ],
-            {},  # No dice functions should be called
-            "🎲 No dice rolled.",
-        ),
-        (
-            "light_and_dark_tie_dark_wins",  # light=2, dark=2, highest of each is 5
-            [
-                {"name": "light", "value": 2},
-                {"name": "dark", "value": 2},
-            ],
-            {
-                # This creates a stateful mock. The outer lambda is immediately called,
-                # returning the inner lambda. The inner lambda closes over
-                # 'rolls_to_return'.  It expects two calls with count=2, returning
-                # predefined rolls.
                 "roll_pool": (
-                    lambda rolls_to_return=[[5, 1], [2, 5]]: lambda count_param: (
-                        rolls_to_return.pop(0)
-                        if count_param == 2 and rolls_to_return
-                        else pytest.fail(
-                            f"Unexpected roll_pool count: {count_param} or too many calls"  # noqa E501
-                        )
-                    )
+                    lambda rolls=[[2, 4], [2, 1, 4]]: lambda c: rolls.pop(0) if (c == 2 and len(rolls) == 2) or (c == 3 and len(rolls) == 1) else pytest.fail(f"Unexpected {c}")
                 )(),
             },
-            # Expected: Dark 5 wins due to tie-breaking rule
-            "Light 5 1 Dark 2 5 => Dark 5 is highest",
+            "Light rolls: 2 4 Dark rolls: 2 1 4 => Highest Dark 4",
         ),
-        (
-            "plain_text_two_numbers",  # user typed "/roll 2 3" as plain text
-            [{"name": "text", "value": "2 3"}],
-            {
-                "roll_pool": lambda count: (
-                    [1, 6]
-                    if count == 2
-                    else (
-                        [2, 5, 3]
-                        if count == 3
-                        else pytest.fail(f"Unexpected roll_pool count: {count}")
-                    )
-                )
-            },
-            "Light 1 6 Dark 2 5 3 => Light 6 is highest",
-        ),
-        (
-            "plain_text_one_number",  # user typed "/roll 2" as plain text
-            [{"name": "text", "value": "2"}],
-            {
-                "roll_pool": lambda count: (
-                    [2, 5, 1]
-                    if count == 2
-                    else pytest.fail(f"Unexpected roll_pool count: {count}")
-                )
-            },
-            "Light 2 5 1 => Light 5 is highest",
-        ),
-        (
-            "numbers_in_name",
-            [
-                {"name": "2", "value": ""},
-                {"name": "3", "value": ""},
-            ],
-            {
-                "roll_pool": lambda count: (
-                    [1, 6]
-                    if count == 2
-                    else (
-                        [2, 4, 5]
-                        if count == 3
-                        else pytest.fail(f"Unexpected roll_pool count: {count}")
-                    )
-                )
-            },
-            "Light 1 6 Dark 2 4 5 => Light 6 is highest",
-        ),
-    ],
-    ids=[
-        "no_options_single_d6",
-        "only_light_gt_1",
-        "only_dark_specified",
-        "light_and_dark_light_highest",
-        "light_and_dark_dark_highest",
-        "light_zero_dark_gt_zero",
-        "light_gt_zero_dark_zero",
-        "light_zero_dark_zero_via_light_option",
-        "light_zero_dark_zero_explicit",
-        "light_and_dark_tie_dark_wins",
-        "plain_text_two_numbers",
-        "plain_text_one_number",
-        "numbers_in_name",
     ],
 )
-async def test_roll_command_scenarios(
-    monkeypatch, test_id, options_data, dice_mocks, expected_message
-):
-    """Tests the /roll command callback with various options and mock dice rolls."""
-
-    # Apply mocks for dice functions in trophybot.dice module
-    # The _roll_command in trophybot.bot will be updated to use these.
+async def test_roll_command(options_data, dice_mocks, expected, monkeypatch):
     if "roll_d6" in dice_mocks:
         monkeypatch.setattr("trophybot.dice.roll_d6", dice_mocks["roll_d6"])
     if "roll_pool" in dice_mocks:
@@ -227,22 +34,13 @@ async def test_roll_command_scenarios(
 
     responses = []
 
-    # We need to reset responses for each parameterized test run,
-    # especially for mocks that depend on call order/count like the new tie test.
-    # The `responses` list is captured by `fake_send_message` closure.
-    # A more robust way for call order dependent mocks might involve a class-based mock
-    # or a more sophisticated counter, but for now, checking len(responses) works.
-    async def fake_send_message(message):
-        responses.append(message)
+    async def fake_send(msg):
+        responses.append(msg)
 
-    # Simulate the interaction object structure
-    # The command handler receives an interaction object.
-    # We assume options are accessed via interaction.data.options
-    fake_interaction_data = SimpleNamespace(options=options_data)
     fake_interaction = SimpleNamespace(
-        response=SimpleNamespace(send_message=fake_send_message),
-        data=fake_interaction_data,
+        response=SimpleNamespace(send_message=fake_send),
+        data=SimpleNamespace(options=options_data),
     )
 
     await roll_command.callback(fake_interaction)
-    assert responses == [expected_message], f"Test case {test_id} failed."
+    assert responses == [expected]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,14 +12,22 @@ from trophybot.bot import roll_command
         ([], {"roll_d6": lambda: 4}, "Die roll: 4"),
         (
             [{"name": "input", "value": "3"}],
-            {"roll_pool": lambda count: [3, 5, 2] if count == 3 else pytest.fail(f"Unexpected {count}")},
+            {
+                "roll_pool": lambda c: (
+                    [3, 5, 2] if c == 3 else pytest.fail(f"Unexpected {c}")
+                )
+            },
             "Dice rolls: 3 5 2 => Highest 5",
         ),
         (
             [{"name": "input", "value": "2 3"}],
             {
                 "roll_pool": (
-                    lambda rolls=[[2, 4], [2, 1, 4]]: lambda c: rolls.pop(0) if (c == 2 and len(rolls) == 2) or (c == 3 and len(rolls) == 1) else pytest.fail(f"Unexpected {c}")
+                    lambda rolls=[[2, 4], [2, 1, 4]]: lambda c: (
+                        rolls.pop(0)
+                        if (c == 2 and len(rolls) == 2) or (c == 3 and len(rolls) == 1)
+                        else pytest.fail(f"Unexpected {c}")
+                    )
                 )(),
             },
             "Light rolls: 2 4 Dark rolls: 2 1 4 => Highest Dark 4",

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -49,9 +49,7 @@ def test_ping(client):
 
 def test_roll_endpoint_no_options(client, monkeypatch):
     """Tests the /roll endpoint with no options (plain /roll)."""
-    monkeypatch.setattr(
-        "trophybot.dice.roll_d6", lambda: 4
-    )  # Mock the correct function
+    monkeypatch.setattr("trophybot.dice.roll_d6", lambda: 4)
     body = json.dumps(
         {
             "type": 2,
@@ -63,20 +61,19 @@ def test_roll_endpoint_no_options(client, monkeypatch):
     data = resp.get_json()
     # type 4 = CHANNEL_MESSAGE_WITH_SOURCE
     assert data["type"] == 4
-    assert data["data"]["content"] == "🎲 You rolled: 4"
+    assert data["data"]["content"] == "Die roll: 4"
 
 
-def test_roll_endpoint_with_light_and_dark_options(client, monkeypatch):
-    """Tests the /roll endpoint with light and dark options."""
+def test_roll_endpoint_with_input_string(client, monkeypatch):
+    """Tests the /roll endpoint with an input string containing two digits."""
 
     # Mock trophybot.dice.roll_pool to return specific results based on count
     def mock_roll_pool(count):
-        if count == 2:  # Expected for light dice
-            return [1, 6]
-        elif count == 3:  # Expected for dark dice
-            return [2, 5, 3]
+        if count == 2:
+            return [2, 4]
+        if count == 3:
+            return [2, 1, 4]
         pytest.fail(f"Unexpected call to roll_pool with count: {count}")
-        return []  # Should not be reached
 
     monkeypatch.setattr("trophybot.dice.roll_pool", mock_roll_pool)
 
@@ -84,10 +81,7 @@ def test_roll_endpoint_with_light_and_dark_options(client, monkeypatch):
         "type": 2,
         "data": {
             "name": "roll",
-            "options": [
-                {"name": "light", "value": 2},
-                {"name": "dark", "value": 3},
-            ],
+            "options": [{"name": "input", "value": "2 3"}],
         },
     }
     body = json.dumps(payload_data).encode()
@@ -96,7 +90,7 @@ def test_roll_endpoint_with_light_and_dark_options(client, monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["type"] == 4
-    expected_content = "Light 1 6 Dark 2 5 3 => Light 6 is highest"
+    expected_content = "Light rolls: 2 4 Dark rolls: 2 1 4 => Highest Dark 4"
     assert data["data"]["content"] == expected_content
 
 


### PR DESCRIPTION
## Summary
- switch `/roll` to take a single `input` parameter
- simplify roll logic to parse digits from the input
- update deploy definition and README
- rewrite tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490384489c8321a5e8428d8abd1116