### PR TITLE
Add TEST_GUILD_ID secret for Cloud Run

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,8 @@ steps:
           --region $_REGION \
           --allow-unauthenticated \
           --update-secrets DISCORD_TOKEN=discord-token:latest \
-          --update-secrets DISCORD_PUBLIC_KEY=discord-pubkey:latest
+          --update-secrets DISCORD_PUBLIC_KEY=discord-pubkey:latest \
+          --update-secrets TEST_GUILD_ID=test-guild-id:latest
 
 # Specify variables (Cloud Build UI will prompt)
 substitutions:

--- a/deploy.py
+++ b/deploy.py
@@ -241,6 +241,8 @@ def deploy_cloud_run():
         "DISCORD_TOKEN=discord-token:latest",
         "--update-secrets",
         "DISCORD_PUBLIC_KEY=discord-pubkey:latest",
+        "--update-secrets",
+        "TEST_GUILD_ID=test-guild-id:latest",
     ]
     print("Deploying to Cloud Run:")
     print(" ".join(deploy_cmd))


### PR DESCRIPTION
## Summary
- add TEST_GUILD_ID secret injection in deploy.py
- update cloudbuild.yaml to inject TEST_GUILD_ID secret for Cloud Run

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a15deb8208321913ae341109d837e